### PR TITLE
Hide several user actions in RHS vehicles

### DIFF
--- a/addons/tm_rhs_vehicle_actions/$PBOPREFIX$
+++ b/addons/tm_rhs_vehicle_actions/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac1\addons\tm_rhs_vehicle_actions

--- a/addons/tm_rhs_vehicle_actions/CfgVehicles.hpp
+++ b/addons/tm_rhs_vehicle_actions/CfgVehicles.hpp
@@ -1,107 +1,128 @@
 class CfgVehicles {
-	class RHS_UH60M_US_base;
-	class RHS_UH60M: RHS_UH60M_US_base {
-		class UserActions {
-			class OpenCargoDoor {
-				condition = "this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class CloseCargoDoor: OpenCargoDoor {
-				condition = "this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class OpenCargoLDoor: OpenCargoDoor {
-				condition = "this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class CloseCargoLDoor: OpenCargoDoor {
-				condition = "this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-		};
-	};
+    class RHS_UH60M_US_base;
+    class RHS_UH60M: RHS_UH60M_US_base {
+        class UserActions {
+            class OpenCargoDoor {
+                condition = "this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class OpenCargoLDoor: OpenCargoDoor {
+                condition = "this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class CloseCargoLDoor: OpenCargoDoor {
+                condition = "this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+        };
+    };
 
-	class RHS_UH1Y_US_base;
-	class RHS_UH1Y: RHS_UH1Y_US_base {
-		class UserActions;
-	};
-	class RHS_UH1Y_FFAR: RHS_UH1Y {
-		class UserActions: UserActions {
-			class OpenCargoDoor {
-				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class CloseCargoDoor: OpenCargoDoor {
-				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class OpenCargoLDoor: OpenCargoDoor {
-				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-			class CloseCargoLDoor: OpenCargoDoor {
-				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
-			};
-		};
-	};
+    class RHS_UH1Y_US_base;
+    class RHS_UH1Y: RHS_UH1Y_US_base {
+        class UserActions;
+    };
+    class RHS_UH1Y_FFAR: RHS_UH1Y {
+        class UserActions: UserActions {
+            class OpenCargoDoor {
+                condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class OpenCargoLDoor: OpenCargoDoor {
+                condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+            class CloseCargoLDoor: OpenCargoDoor {
+                condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+            };
+        };
+    };
 
-	class RHS_C130J_Base;
-	class RHS_C130J: RHS_C130J_Base {
-		class UserActions {
-			class OpenRamp {
-				condition = "(this animationSourcePhase 'ramp' <= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class LeverRamp: OpenRamp {
-				condition = "this animationSourcePhase 'ramp' != 0.65 and (alive this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class CloseRamp: OpenRamp {
-				condition = "(this animationSourcePhase 'ramp' >= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class MoveInside: OpenRamp {
-				condition = "false";
-			};
-			class VehicleParadrop: MoveInside {
-				condition = "(count (attachedObjects this) > 0) AND ('man' countType (attachedObjects this) == 0) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-		};
-	};
+    class RHS_C130J_Base;
+    class RHS_C130J: RHS_C130J_Base {
+        class UserActions {
+            class OpenMenu {
+                condition = "((call rhsusf_fnc_findPlayer) in this) and ((""driver"" in assignedVehicleRole (call rhsusf_fnc_findPlayer)) or (""Turret"" in assignedVehicleRole (call rhsusf_fnc_findPlayer)));";
+            };
+            class OpenRamp {
+                condition = "(this animationSourcePhase 'ramp' <= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class LeverRamp: OpenRamp {
+                condition = "this animationSourcePhase 'ramp' != 0.65 and (alive this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class CloseRamp: OpenRamp {
+                condition = "(this animationSourcePhase 'ramp' >= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class MoveInside: OpenRamp {
+                condition = "false";
+            };
+            class VehicleParadrop: MoveInside {
+                condition = "(count (attachedObjects this) > 0) AND ('man' countType (attachedObjects this) == 0) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+        };
+    };
 
-	class APC_Tracked_02_base_F;
-	class rhsusf_m113tank_base: APC_Tracked_02_base_F {
-		class UserActions {
-			class OpenCargoDoor {
-				condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class CloseCargoDoor: OpenCargoDoor {
-				condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-		};
-	};
+    class Wheeled_APC_F;
+    class rhs_btr_base: Wheeled_APC_F {
+        class UserActions {
+            class openDriverViewHatch;
+            class openl_door: openDriverViewHatch {
+                condition = "false";
+            };
+            class openr_door: openl_door {
+                condition = "false";
+            };
+            class opent_door: openr_door {
+                condition = "false";
+            };
+        };
+    };
 
-	class APC_Tracked_03_base_F;
-	class RHS_M2A2_Base: APC_Tracked_03_base_F {
-		class UserActions {
-			class OpenCargoDoor {
-				condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class CloseCargoDoor: OpenCargoDoor {
-				condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-		};
-	};
+    class APC_Tracked_02_base_F;
+    class rhsusf_m113tank_base: APC_Tracked_02_base_F {
+        class UserActions {
+            class OpenCargoDoor {
+                condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+        };
+    };
 
-	class MRAP_01_base_F;
-	class rhsusf_RG33L_base: MRAP_01_base_F {
-		class OpenCargoDoor {
-			condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-		};
-		class CloseCargoDoor: OpenCargoDoor {
-			condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-		};
-	};
+    class APC_Tracked_03_base_F;
+    class RHS_M2A2_Base: APC_Tracked_03_base_F {
+        class UserActions {
+            class OpenCargoDoor {
+                condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+        };
+    };
 
-	class Truck_01_base_F;
-	class rhsusf_caiman_base: Truck_01_base_F {
-		class UserActions {
-			class OpenCargoDoor {
-				condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-			class CloseCargoDoor: OpenCargoDoor {
-				condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
-			};
-		};
-	};
+    class MRAP_01_base_F;
+    class rhsusf_RG33L_base: MRAP_01_base_F {
+        class UserActions {
+            class OpenCargoDoor {
+                condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+        };
+    };
+
+    class Truck_01_base_F;
+    class rhsusf_caiman_base: Truck_01_base_F {
+        class UserActions {
+            class OpenCargoDoor {
+                condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+            };
+        };
+    };
 };

--- a/addons/tm_rhs_vehicle_actions/CfgVehicles.hpp
+++ b/addons/tm_rhs_vehicle_actions/CfgVehicles.hpp
@@ -1,0 +1,107 @@
+class CfgVehicles {
+	class RHS_UH60M_US_base;
+	class RHS_UH60M: RHS_UH60M_US_base {
+		class UserActions {
+			class OpenCargoDoor {
+				condition = "this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class CloseCargoDoor: OpenCargoDoor {
+				condition = "this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class OpenCargoLDoor: OpenCargoDoor {
+				condition = "this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class CloseCargoLDoor: OpenCargoDoor {
+				condition = "this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+		};
+	};
+
+	class RHS_UH1Y_US_base;
+	class RHS_UH1Y: RHS_UH1Y_US_base {
+		class UserActions;
+	};
+	class RHS_UH1Y_FFAR: RHS_UH1Y {
+		class UserActions: UserActions {
+			class OpenCargoDoor {
+				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class CloseCargoDoor: OpenCargoDoor {
+				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorRB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class OpenCargoLDoor: OpenCargoDoor {
+				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' == 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+			class CloseCargoLDoor: OpenCargoDoor {
+				condition = "(this animationphase 'hide_CargoDoors' !=1) and this doorPhase 'doorLB' > 0 and (alive this) and ((call rhsusf_fnc_findPlayer) isEqualTo (driver this));";
+			};
+		};
+	};
+
+	class RHS_C130J_Base;
+	class RHS_C130J: RHS_C130J_Base {
+		class UserActions {
+			class OpenRamp {
+				condition = "(this animationSourcePhase 'ramp' <= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class LeverRamp: OpenRamp {
+				condition = "this animationSourcePhase 'ramp' != 0.65 and (alive this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class CloseRamp: OpenRamp {
+				condition = "(this animationSourcePhase 'ramp' >= 0.65) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class MoveInside: OpenRamp {
+				condition = "false";
+			};
+			class VehicleParadrop: MoveInside {
+				condition = "(count (attachedObjects this) > 0) AND ('man' countType (attachedObjects this) == 0) AND Alive(this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+		};
+	};
+
+	class APC_Tracked_02_base_F;
+	class rhsusf_m113tank_base: APC_Tracked_02_base_F {
+		class UserActions {
+			class OpenCargoDoor {
+				condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class CloseCargoDoor: OpenCargoDoor {
+				condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+		};
+	};
+
+	class APC_Tracked_03_base_F;
+	class RHS_M2A2_Base: APC_Tracked_03_base_F {
+		class UserActions {
+			class OpenCargoDoor {
+				condition = "this doorPhase 'ramp' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class CloseCargoDoor: OpenCargoDoor {
+				condition = "this doorPhase 'ramp' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+		};
+	};
+
+	class MRAP_01_base_F;
+	class rhsusf_RG33L_base: MRAP_01_base_F {
+		class OpenCargoDoor {
+			condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+		};
+		class CloseCargoDoor: OpenCargoDoor {
+			condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+		};
+	};
+
+	class Truck_01_base_F;
+	class rhsusf_caiman_base: Truck_01_base_F {
+		class UserActions {
+			class OpenCargoDoor {
+				condition = "this doorPhase 'DoorB' == 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+			class CloseCargoDoor: OpenCargoDoor {
+				condition = "this doorPhase 'DoorB' > 0 and ((call rhsusf_fnc_findPlayer) in this) and !(""cargo"" in assignedVehicleRole (call rhsusf_fnc_findPlayer));";
+			};
+		};
+	};
+};

--- a/addons/tm_rhs_vehicle_actions/config.cpp
+++ b/addons/tm_rhs_vehicle_actions/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		name = "Tweak availability of RHS vehicle user actions such as opening rear M113 door";
+		author = "Bear";
+		url = "http://www.teamonetactical.com";
+		units[] = {};
+		weapons[] = {};
+		requiredAddons[] = {
+			"RHS_US_A2_AirImport",
+			"RHS_US_A2Port_Armor",
+			"rhsusf_c_Caiman",
+			"rhsusf_c_m113",
+			"rhsusf_c_RG33L"
+		};
+		requiredVersion = REQUIRED_VERSION;
+		VERSION_CONFIG;
+	};
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/tm_rhs_vehicle_actions/config.cpp
+++ b/addons/tm_rhs_vehicle_actions/config.cpp
@@ -1,22 +1,23 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-	class ADDON {
-		name = "Tweak availability of RHS vehicle user actions such as opening rear M113 door";
-		author = "Bear";
-		url = "http://www.teamonetactical.com";
-		units[] = {};
-		weapons[] = {};
-		requiredAddons[] = {
-			"RHS_US_A2_AirImport",
-			"RHS_US_A2Port_Armor",
-			"rhsusf_c_Caiman",
-			"rhsusf_c_m113",
-			"rhsusf_c_RG33L"
-		};
-		requiredVersion = REQUIRED_VERSION;
-		VERSION_CONFIG;
-	};
+    class ADDON {
+        name = "Tweak availability of RHS vehicle user actions such as opening rear M113 door";
+        author = "Bear";
+        url = "http://www.teamonetactical.com";
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "RHS_US_A2_AirImport",
+            "RHS_US_A2Port_Armor",
+            "rhsusf_c_Caiman",
+            "rhsusf_c_m113",
+            "rhsusf_c_RG33L",
+            "rhs_c_btr"
+        };
+        requiredVersion = REQUIRED_VERSION;
+        VERSION_CONFIG;
+    };
 };
 
 #include "CfgVehicles.hpp"

--- a/addons/tm_rhs_vehicle_actions/script_component.hpp
+++ b/addons/tm_rhs_vehicle_actions/script_component.hpp
@@ -2,4 +2,3 @@
 
 #include "\x\tac1\addons\tm_main\script_mod.hpp"
 #include "\x\tac1\addons\tm_main\script_macros.hpp"
-

--- a/addons/tm_rhs_vehicle_actions/script_component.hpp
+++ b/addons/tm_rhs_vehicle_actions/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT tm_rhs_vehicle_actions
+
+#include "\x\tac1\addons\tm_main\script_mod.hpp"
+#include "\x\tac1\addons\tm_main\script_macros.hpp"
+


### PR DESCRIPTION
Restricts availability of actions like opening ramps and initiating the C130 cargo drop to the vehicle crew (excluding passengers)