### PR TITLE
Tweak ACE Adv Fatigue settings

### DIFF
--- a/addons/tm_ace_settings/ace_settings.hpp
+++ b/addons/tm_ace_settings/ace_settings.hpp
@@ -10,6 +10,16 @@ class ACE_Settings {
         value = 2;
 		force = 1;
     };
+    class ace_advanced_fatigue_loadFactor {
+        typeName = "SCALAR";
+        value = 0.8;
+        force = 1;
+    };
+    class ace_advanced_fatigue_terrainGradientFactor {
+        typeName = "SCALAR";
+        value = 0.9;
+        force = 1;
+    };
     class ace_map_DefaultChannel {
         typeName = "NUMBER";
         value = 1;


### PR DESCRIPTION
Load factor: Increases or decreases how much weight influences the players performance. Zero means equipment weight has no performance influence.

Terrain gradient factor: Sets how much steep terrain increases stamina loss. Higher means higher stamina loss.