### PR TITLE
Removed M1 Liner variant from US 1970 loadout

### DIFF
--- a/addons/tm_tmf_loadouts/loadouts/us_army_1970_odgreen.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_1970_odgreen.hpp
@@ -56,8 +56,7 @@ class r : baseMan
     headgear[] = 
     {
         "rhsgref_helmet_M1_bare",
-        "rhsgref_helmet_M1_bare_alt01",
-        "rhsgref_helmet_M1_liner"
+        "rhsgref_helmet_M1_bare_alt01"
     };
     vest[] = {"usm_vest_LBE_rm"};
     backpack[] = {"CUP_B_AlicePack_Khaki"};


### PR DESCRIPTION
It apparently has no armour value.

Also hope you're happy @Fingers