### PR TITLE
3CB Advanced Medical Update + MAT Changes

### DIFF
--- a/addons/tm_tmf_loadouts/loadouts/gb_des_1985.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_des_1985.hpp
@@ -83,8 +83,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -110,10 +112,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_DDPM9"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_DDPM_Rifleman_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+       		LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };
@@ -558,7 +565,8 @@ class eng : car
 	{
 		LIST_4("ClaymoreDirectionalMine_Remote_Mag")
 	};
-	backpackItems[] = {
+	backpackItems[] = 
+	{
 		"ToolKit",
 		LIST_2("DemoCharge_Remote_Mag"),
 		LIST_2("SLAMDirectionalMine_Wire_Mag")

--- a/addons/tm_tmf_loadouts/loadouts/gb_des_1990.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_des_1990.hpp
@@ -83,8 +83,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -110,10 +112,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_DDPM9"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_DDPM_Rifleman_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };

--- a/addons/tm_tmf_loadouts/loadouts/gb_des_2000.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_des_2000.hpp
@@ -83,8 +83,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+       		LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+       		"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -110,10 +112,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_DDPM9"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_DDPM_Rifleman_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };

--- a/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015.hpp
@@ -404,6 +404,7 @@ class matac : r
 class matag : car
 {
 	displayName = "MAT Assistant Gunner";
+	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
 	backpackItems[] =
 	{
 		LIST_2("rhs_mag_maaws_HEAT"),

--- a/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015.hpp
@@ -108,8 +108,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+       		LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -129,7 +131,7 @@ class g : r
 class mar : r
 {
 	displayName = "Designated Marksman";
-    vest[] = {"UK3CB_BAF_V_Osprey_Marksman_A"};
+    	vest[] = {"UK3CB_BAF_V_Osprey_Marksman_A"};
 	primaryWeapon[] = {"UK3CB_BAF_L129A1"};
 	bipod[] = {"UK3CB_underbarrel_acc_bipod"};
 	attachment[] = {"UK3CB_BAF_TA648"};
@@ -149,10 +151,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_Medic_C"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_MTP_Medic_L_A"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };
@@ -369,8 +376,14 @@ class hmgag : car
 class matg : car
 {
 	displayName = "MAT Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
+	secondaryWeapon[] = {"rhs_weap_maaws"};
+	secondaryAttachments[] = {"rhs_optic_maaws"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
+	magazines[] +=
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",
@@ -381,13 +394,21 @@ class matg : car
 class matac : r
 {
 	displayName = "MAT Ammo Carrier";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 };
 class matag : car
 {
 	displayName = "MAT Assistant Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",

--- a/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015_h.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015_h.hpp
@@ -108,8 +108,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -149,10 +151,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_Medic_C"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_MTP_Medic_H_A","UK3CB_BAF_B_Bergen_MTP_Medic_H_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };
@@ -352,7 +359,7 @@ class hmgag : car
 {
 	displayName = "HMG Assistant Gunner";	
 	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
-    secondaryWeapon[] = {"UK3CB_BAF_Tripod"};	
+    	secondaryWeapon[] = {"UK3CB_BAF_Tripod"};	
 	linkedItems[] =
 	{
 		"ItemMap",
@@ -369,8 +376,14 @@ class hmgag : car
 class matg : car
 {
 	displayName = "MAT Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
+	secondaryWeapon[] = {"rhs_weap_maaws"};
+	secondaryAttachments[] = {"rhs_optic_maaws"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",
@@ -381,13 +394,21 @@ class matg : car
 class matac : r
 {
 	displayName = "MAT Ammo Carrier";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 };
 class matag : car
 {
 	displayName = "MAT Assistant Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_NLAW_Launcher"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",

--- a/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015_h.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_mtp_2015_h.hpp
@@ -404,6 +404,7 @@ class matac : r
 class matag : car
 {
 	displayName = "MAT Assistant Gunner";
+	backpack[] = {"UK3CB_BAF_B_Carryall_MTP"};
 	backpackItems[] =
 	{
 		LIST_2("rhs_mag_maaws_HEAT"),

--- a/addons/tm_tmf_loadouts/loadouts/gb_wood_1980.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_wood_1980.hpp
@@ -477,15 +477,15 @@ class sn : r
 class sp : sn
 {
     displayName = "Spotter";
-    scope[] = {"rhsusf_acc_ACOG_d"};
-	primaryWeapon[] = {"UK3CB_BAF_L1A1"};
+    primaryWeapon[] = {"UK3CB_BAF_L1A1"};
     magazines[] =
     {
-		LIST_7("UK3CB_BAF_762_20Rnd"),
+	LIST_7("UK3CB_BAF_762_20Rnd"),
         LIST_2("UK3CB_BAF_762_20Rnd_T"),
         LIST_2("HandGrenade"),
         LIST_2("SmokeShell"),
-		LIST_4("rhsusf_mag_7x45acp_MHP")
+	LIST_4("rhsusf_mag_7x45acp_MHP"),
+	LIST_2("UK3CB_BAF_9_13Rnd")
     };
         linkedItems[] =
     {

--- a/addons/tm_tmf_loadouts/loadouts/gb_wood_1980.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_wood_1980.hpp
@@ -1,6 +1,6 @@
 /* assignGear specific macros */
 
-tooltip = "Author: Sam, modified Deltas original loadout";
+tooltip = "Author: Sam";
 
 class baseMan {// Weaponless baseclass
     displayName = "Unarmed";
@@ -51,7 +51,7 @@ class r : baseMan
 {
     displayName = "Rifleman";
     headgear[] = {"rhs_beanie_green"};
-	vest[] = {"UK3CB_BAF_V_PLCE_Webbing_Plate_DPMW"};
+    vest[] = {"UK3CB_BAF_V_PLCE_Webbing_Plate_DPMW"};
     backpack[] = {"UK3CB_BAF_B_Carryall_DPMW"};
     primaryWeapon[] = {"UK3CB_BAF_L1A1"};
     scope[] = {};
@@ -63,11 +63,13 @@ class r : baseMan
         LIST_2("HandGrenade"),
         LIST_2("SmokeShell")
     };
-	items[] =
-	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
-	};
+    items[] = 
+    {
+        LIST_5("ACE_fieldDressing"),
+        LIST_3("ACE_quikclot"),
+        "ACE_morphine",
+        "ACE_tourniquet"
+    };
 };
 class g : r
 {
@@ -87,14 +89,20 @@ class car : r
 };
 class m : car
 {
-    displayName = "Medic";
+    	displayName = "Medic";
 	headgear[] = {"H_Booniehat_oli"};
 	backpack[] = {"CUP_B_CivPack_WDL"};
-	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+	backpackItems[] = 
+	{
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("SmokeShell")
 	};
 };
@@ -112,7 +120,7 @@ class smg : r
 class ftl : g
 {
     displayName = "Fireteam Leader";
-	headgear[] = {"UK3CB_BAF_H_Beret_GG"};
+    headgear[] = {"UK3CB_BAF_H_Beret_GG"};
     magazines[] +=
     {
         /*LIST_2("1Rnd_SmokeGreen_Grenade_shell"),

--- a/addons/tm_tmf_loadouts/loadouts/gb_wood_1985.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_wood_1985.hpp
@@ -84,8 +84,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -111,10 +113,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_DPMW9"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_DPMW_Rifleman_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };

--- a/addons/tm_tmf_loadouts/loadouts/gb_wood_1990.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_wood_1990.hpp
@@ -83,8 +83,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -110,10 +112,15 @@ class m : car
 	vest[] = {"UK3CB_BAF_V_Osprey_DPMW9"};
 	backpack[] = {"UK3CB_BAF_B_Bergen_DPMW_Rifleman_B"};
 	backpackItems[] = {
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };

--- a/addons/tm_tmf_loadouts/loadouts/gb_wood_2000.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/gb_wood_2000.hpp
@@ -83,8 +83,10 @@ class r : baseMan
 	};
 	items[] =
 	{
-		LIST_3("ACE_fieldDressing"),
-		"ACE_morphine"
+        	LIST_5("ACE_fieldDressing"),
+        	LIST_3("ACE_quikclot"),
+        	"ACE_morphine",
+        	"ACE_tourniquet"
 	};
 };
 class g : r
@@ -111,10 +113,15 @@ class m : car
 	backpack[] = {"UK3CB_BAF_B_Bergen_DPMW_Rifleman_B"};
 	backpackItems[] =
 	{
-		LIST_15("ACE_fieldDressing"),
-		LIST_10("ACE_morphine"),
-		LIST_6("ACE_epinephrine"),
-		LIST_2("ACE_bloodIV"),
+        	LIST_15("ACE_fieldDressing"),
+        	LIST_20("ACE_elasticBandage"),
+        	LIST_20("ACE_packingBandage"),
+        	LIST_2("ACE_atropine"),
+        	LIST_10("ACE_morphine"),
+        	LIST_10("ACE_epinephrine"),
+        	LIST_5("ACE_tourniquet"),
+        	LIST_6("ACE_bloodIV"),
+        	LIST_1("ACE_surgicalKit"),
 		LIST_2("rhs_mag_an_m8hc")
 	};
 };
@@ -316,8 +323,14 @@ class hmgag : car
 class matg : car
 {
 	displayName = "MAT Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_AT4_CS_AP_Launcher"};
+	secondaryWeapon[] = {"rhs_weap_maaws"};
+	secondaryAttachments[] = {"rhs_optic_maaws"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_DPMW"};
+	magazines[] +=
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",
@@ -328,14 +341,22 @@ class matg : car
 class matac : r
 {
 	displayName = "MAT Ammo Carrier";
-	secondaryWeapon[] = {"UK3CB_BAF_AT4_CS_AT_Launcher"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_DPMW"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 };
 class matag : car
 {
 	displayName = "MAT Assistant Gunner";
-	secondaryWeapon[] = {"UK3CB_BAF_AT4_CS_AP_Launcher"};
 	backpack[] = {"UK3CB_BAF_B_Carryall_DPMW"};
+	backpackItems[] =
+	{
+		LIST_2("rhs_mag_maaws_HEAT"),
+		"rhs_mag_maaws_HE"
+	};
 	linkedItems[] =
 	{
 		"ItemMap",


### PR DESCRIPTION
- All loadouts updated to contain advanced medical supplies
- MAT on the modern loadouts changed to use the MAAWS, it's not accurate, but it fits better with 1Tac's default ORBAT.