### PR TITLE
Add PBO to disable default ACRE Racks

### DIFF
--- a/addons/tm_disable_acre_racks/$PBOPREFIX$
+++ b/addons/tm_disable_acre_racks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac1\addons\tm_disable_acre_racks

--- a/addons/tm_disable_acre_racks/CfgEventHandlers.hpp
+++ b/addons/tm_disable_acre_racks/CfgEventHandlers.hpp
@@ -1,0 +1,6 @@
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/tm_disable_acre_racks/XEH_preInit.sqf
+++ b/addons/tm_disable_acre_racks/XEH_preInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+["AllVehicles", "Init", {
+    params ["_vehicle"];
+    
+    private _classname = typeOf _vehicle;
+	
+	// Set vehicles as already initialized which will prevent default racks being added to the vehicles.
+    if (isClass (configFile >> "CfgVehicles" >> _classname >> "AcreRacks")) then {
+        _vehicle setVariable ["acre_sys_rack_initialized",true];
+    };
+}, nil, nil, true] call CBA_fnc_addClassEventHandler;

--- a/addons/tm_disable_acre_racks/config.cpp
+++ b/addons/tm_disable_acre_racks/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = "Disable ACRE Racks";
+        author = "Snippers";
+        url = "http://www.teamonetactical.com";
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac1_tm_main"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/tm_disable_acre_racks/script_component.hpp
+++ b/addons/tm_disable_acre_racks/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT tm_disable_acre_racks
+
+#include "\x\tac1\addons\tm_main\script_mod.hpp"
+#include "\x\tac1\addons\tm_main\script_macros.hpp"


### PR DESCRIPTION
**What This Pull Request does**
- Disables default vehicle rack initialization (can still be added via API) so vehicles don't have any racked radios.

**Justification**
- ACRE2 introduced vehicle racks. We currently don't handle these in TMF etc. Vanilla ACRE behaviour sets these ups on vehicles giving radio pathways that mission makers at 1Tac may not have not forseen. In coops this is probably less of an issue but in TvTs might open communication pathways. This is a stopgap solution until TMF handles it