### PR TITLE
Allow compass to be used by any aircraft seat with an optic screen

### DIFF
--- a/addons/tm_helicam/functions/fn_checkConditions.sqf
+++ b/addons/tm_helicam/functions/fn_checkConditions.sqf
@@ -2,12 +2,12 @@
 
 params ["_playerUnit"];
 
-if ((vehicle _playerUnit) isKindOf "RHS_MELB_base" && {gunner (vehicle _playerUnit) isEqualTo _playerUnit}) then {
+private _veh = vehicle _playerUnit;
+if (_veh isKindOf "Air" && {isClass (([_veh,_playerUnit call CBA_fnc_turretPath] call CBA_fnc_getTurret) >> "OpticsIn")}) then {
     private _index = missionNamespace getVariable [QGVAR(draw3dIndex),-1];
     if (_index isEqualTo -1) then {
         GVAR(draw3dIndex) = addMissionEventHandler ["Draw3D",{ _this call FUNC(drawCompass); }];
     };
-    
 } else {
     private _index = missionNamespace getVariable [QGVAR(draw3dIndex),-1];
     if !(_index isEqualTo -1) then {


### PR DESCRIPTION
**What This Pull Request does**
- Previously the compass was only available to gunners on the RHS MELB. This adds a proper conditional check to allow the compass to be used on any seat with an optic screen. 