### PR TITLE
Loadout Tweaks

### DIFF
--- a/addons/tm_tmf_loadouts/loadouts/afr_militia.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/afr_militia.hpp
@@ -131,7 +131,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/arvn_1966.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/arvn_1966.hpp
@@ -101,7 +101,7 @@ class car : r
 class m : r
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_portuguese_dpm_akm.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_portuguese_dpm_akm.hpp
@@ -93,7 +93,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_tigerstripe_desert.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_tigerstripe_desert.hpp
@@ -94,7 +94,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_tigerstripe_m16.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/generic_paramilitary_tigerstripe_m16.hpp
@@ -98,7 +98,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/greek_army_2018.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/greek_army_2018.hpp
@@ -102,7 +102,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/racs_1990.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/racs_1990.hpp
@@ -96,7 +96,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/us_army_1970_odgreen.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_1970_odgreen.hpp
@@ -132,7 +132,7 @@ class m : ra
         LIST_3("rhsusf_5Rnd_Slug"),
         LIST_2("rhs_mag_an_m8hc")
     };
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/us_army_1980_erdl.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_1980_erdl.hpp
@@ -89,7 +89,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/us_army_1985_m81.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_1985_m81.hpp
@@ -96,7 +96,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/us_army_rangers_1990_m81.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_rangers_1990_m81.hpp
@@ -97,7 +97,7 @@ class g : r
 class m : r
 {
     displayName = "Medic";
-    backPack[] = {"usm_pack_m5_medic"};
+    backPack[] = {"usm_pack_alice"};
     backpackItems[] = 
     {
         LIST_15("ACE_fieldDressing"),

--- a/addons/tm_tmf_loadouts/loadouts/us_army_rangers_2000_m81.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_army_rangers_2000_m81.hpp
@@ -98,7 +98,7 @@ class g : r
 class m : r
 {
     displayName = "Medic";
-    backPack[] = {"usm_pack_m5_medic"};
+    backPack[] = {"usm_pack_alice"};
     backpackItems[] = 
     {
         LIST_15("ACE_fieldDressing"),

--- a/addons/tm_tmf_loadouts/loadouts/us_marines_1985_m81.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_marines_1985_m81.hpp
@@ -127,7 +127,7 @@ class g : r
 class m : r
 {
     displayName = "Medic";
-    backPack[] = {"usm_pack_m5_medic"};
+    backPack[] = {"usm_pack_alice"};
     backpackItems[] = 
     {
         LIST_15("ACE_fieldDressing"),

--- a/addons/tm_tmf_loadouts/loadouts/us_marines_1990_dbdu.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_marines_1990_dbdu.hpp
@@ -98,7 +98,6 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),

--- a/addons/tm_tmf_loadouts/loadouts/us_marines_2003_oif_dcu.hpp
+++ b/addons/tm_tmf_loadouts/loadouts/us_marines_2003_oif_dcu.hpp
@@ -98,7 +98,7 @@ class car : r
 class m : car
 {
     displayName = "Medic";
-    backpack[] = {"usm_pack_m5_medic"};
+    backpack[] = {"usm_pack_alice"};
     backpackItems[] = {
         LIST_15("ACE_fieldDressing"),
         LIST_20("ACE_elasticBandage"),


### PR DESCRIPTION
Abex discovered that some of the USMC loadouts have a backpack (usm_pack_m5_medic) that adds its own field dressings from USM (usm_fielddressing), these extra items overfill the backpacks which is obviously an issue. I just changed the backpacks to a suitable alternative.

Also checked other loadouts for the same issue and changed them too.