### PR TITLE
CfgLoadouts.hpp SPO briefing fix

### DIFF
--- a/addons/tm_tmf_loadouts/CfgLoadouts.hpp
+++ b/addons/tm_tmf_loadouts/CfgLoadouts.hpp
@@ -1249,19 +1249,19 @@ class CfgLoadouts
     };
     class TALIBAN_REGULAR_2021
     {
-        displayName = "Taliban Regulars (2021-, AKMs&M4s)";
+        displayName = "Taliban Regulars (2021-, AKMs and M4s)";
         category = "Other";
         #include "loadouts\taliban_regular_2021.hpp"
     };
     class TALIBAN_SHOCK_2021
     {
-        displayName = "Taliban Shock Fighters (2021-, AKMs&M4s)";
+        displayName = "Taliban Shock Fighters (2021-, AKMs and M4s)";
         category = "Other";
         #include "loadouts\taliban_shock_2021.hpp"
     };
     class TALIBAN_ELITE_2021
     {
-        displayName = "Taliban Elite Fighters (2021-, AKMs&M4s)";
+        displayName = "Taliban Elite Fighters (2021-, AKMs and M4s)";
         category = "Other";
         #include "loadouts\taliban_elite_2021.hpp"
     };


### PR DESCRIPTION
I just noticed that the "&" sign is breaking the "available loadouts" briefing  in SPO. This PR removes the "&"s